### PR TITLE
Save related improvements

### DIFF
--- a/source/emulator/cartridge/backup/backup_file.hpp
+++ b/source/emulator/cartridge/backup/backup_file.hpp
@@ -25,23 +25,23 @@ namespace nba {
 
 class BackupFile {
 public:
-  
+
   static auto OpenOrCreate(std::string const& save_path,
                            std::vector<size_t> const& valid_sizes,
                            int& default_size) -> std::unique_ptr<BackupFile> {
     namespace fs = std::experimental::filesystem;
-    
+
     bool create = true;
     auto flags = std::ios::binary | std::ios::in | std::ios::out;
     std::unique_ptr<BackupFile> file { new BackupFile() };
-    
+
     /* TODO: check file type and permissions? */
-    if (fs::exists(save_path)) {
+    if (fs::is_regular_file(save_path)) {
       auto size = fs::file_size(save_path);
 
       auto begin = valid_sizes.begin();
       auto end = valid_sizes.end();
-      
+
       if (std::find(begin, end, size) != end) {
         file->stream.open(save_path, flags);
         if (file->stream.fail()) {
@@ -55,7 +55,7 @@ public:
     }
 
     file->file_size = default_size;
-    
+
     /* A new save file is created either when no file exists yet,
      * or when the existing file has an invalid size.
      */
@@ -67,17 +67,17 @@ public:
       file->memory.reset(new std::uint8_t[default_size]);
       file->MemorySet(0, default_size, 0xFF);
     }
-    
+
     return file;
   }
-  
+
   auto Read(unsigned index) -> std::uint8_t {
     if (index >= file_size) {
       throw std::runtime_error("BackupFile: out-of-bounds index while reading.");
     }
     return memory[index];
   }
-  
+
   void Write(unsigned index, std::uint8_t value) {
     if (index >= file_size) {
       throw std::runtime_error("BackupFile: out-of-bounds index while writing.");
@@ -87,7 +87,7 @@ public:
       Update(index, 1);
     }
   }
-  
+
   void MemorySet(unsigned index, size_t length, std::uint8_t value) {
     if ((index + length) > file_size) {
       throw std::runtime_error("BackupFile: out-of-bounds index while setting memory.");
@@ -97,7 +97,7 @@ public:
       Update(index, length);
     }
   }
-  
+
   void Update(unsigned index, size_t length) {
     if ((index + length) > file_size) {
       throw std::runtime_error("BackupFile: out-of-bounds index while updating file.");
@@ -105,15 +105,15 @@ public:
     stream.seekg(index);
     stream.write((char*)&memory[index], length);
   }
-  
+
   bool auto_update = true;
-  
+
 private:
   BackupFile() { }
-  
+
   size_t file_size;
   std::fstream stream;
   std::unique_ptr<std::uint8_t[]> memory;
-}; 
+};
 
 } // namespace nba

--- a/source/emulator/core/cpu-memory.inl
+++ b/source/emulator/core/cpu-memory.inl
@@ -7,13 +7,13 @@
 
 inline std::uint32_t CPU::ReadBIOS(std::uint32_t address) {
   int shift = (address & 3) * 8;
-  
+
   address &= ~3;
 
   if (address >= 0x4000) {
     return ReadUnused(address) >> shift;
   }
-  
+
   if (state.r15 >= 0x4000) {
     return memory.bios_latch >> shift;
   }
@@ -25,14 +25,14 @@ inline std::uint32_t CPU::ReadBIOS(std::uint32_t address) {
 
 inline std::uint32_t CPU::ReadUnused(std::uint32_t address) {
   std::uint32_t result = 0;
-  
+
   if (dma.IsRunning()) {
     return dma.GetOpenBusValue() >> ((address & 3) * 8);
   }
 
   if (state.cpsr.f.thumb) {
     auto r15 = state.r15;
-  
+
     switch (r15 >> 24) {
     case REGION_EWRAM:
     case REGION_PRAM:
@@ -71,7 +71,7 @@ inline std::uint32_t CPU::ReadUnused(std::uint32_t address) {
   } else {
     result = GetPrefetchedOpcode(1);
   }
-    
+
   return result >> ((address & 3) * 8);
 }
 
@@ -138,8 +138,8 @@ inline auto CPU::ReadByte(std::uint32_t address, Access access) -> std::uint8_t 
     if (memory.rom.backup_sram) {
       return memory.rom.backup_sram->Read(address);
     }
-    return 0;
-  }  
+    return 0xFF;
+  }
   default: {
     PrefetchStepRAM(cycles);
     return ReadUnused(address);
@@ -154,7 +154,7 @@ inline auto CPU::ReadHalf(std::uint32_t address, Access access) -> std::uint16_t
   if (page != REGION_SRAM_1 && page != REGION_SRAM_2) {
     address &= ~1;
   }
-  
+
   switch (page) {
   case REGION_BIOS: {
     PrefetchStepRAM(cycles);
@@ -187,7 +187,7 @@ inline auto CPU::ReadHalf(std::uint32_t address, Access access) -> std::uint16_t
   case REGION_OAM: {
     PrefetchStepRAM(cycles);
     return Read<std::uint16_t>(ppu.oam, address & 0x3FF);
-  } 
+  }
   /* 0x0DXXXXXX may be used to read/write from EEPROM */
   case REGION_ROM_W2_H: {
     PrefetchStepROM(address, cycles);
@@ -227,7 +227,7 @@ inline auto CPU::ReadHalf(std::uint32_t address, Access access) -> std::uint16_t
     if (memory.rom.backup_sram) {
       return memory.rom.backup_sram->Read(address) * 0x0101;
     }
-    return 0;
+    return 0xFFFF;
   }
   default: {
     PrefetchStepRAM(cycles);
@@ -243,7 +243,7 @@ inline auto CPU::ReadWord(std::uint32_t address, Access access) -> std::uint32_t
   if (page != REGION_SRAM_1 && page != REGION_SRAM_2) {
     address &= ~3;
   }
-  
+
   switch (page) {
   case REGION_BIOS: {
     PrefetchStepRAM(cycles);
@@ -308,7 +308,7 @@ inline auto CPU::ReadWord(std::uint32_t address, Access access) -> std::uint32_t
     if (memory.rom.backup_sram) {
       return memory.rom.backup_sram->Read(address) * 0x01010101;
     }
-    return 0;
+    return 0xFFFFFFFF;
   }
   default: {
     PrefetchStepRAM(cycles);
@@ -436,7 +436,7 @@ inline void CPU::WriteHalf(std::uint32_t address, std::uint16_t value, Access ac
       break;
     }
     break;
-  }  
+  }
   case REGION_SRAM_1:
   case REGION_SRAM_2: {
     PrefetchStepROM(address, cycles);


### PR DESCRIPTION
`fs::is_regular_file` seems to be a better fit for the save file than `fs::exists` and returning `0xFF` for non-existing save types makes it pass the [tests](https://github.com/jsmolka/gba-suite/tree/master/save) I have written.

VS Code removed some white spaces again, hope that's ok.