### PR TITLE
Fix automated windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,15 @@ jobs:
         shell: cmd
 
       - name: Setup vcpkg
-        run: vcpkg integrate install
-        shell: cmd
+        run: |
+          Remove-Item "C:\vcpkg" -Recurse -Force
+          $Uri = 'https://github.com/Microsoft/vcpkg.git'
+          $InstallDir = 'C:\vcpkg'
+
+          git clone -b 2020.04 --single-branch --depth=1 $Uri $InstallDir -q
+
+          Invoke-Expression "$InstallDir\bootstrap-vcpkg.bat"
+          vcpkg integrate install
 
       - name: Setup SDL2
         run: vcpkg install sdl2:x64-windows


### PR DESCRIPTION
A workaround has been found a person in the [actions](https://github.com/actions/virtual-environments/issues/1152) repository. It seems like the newest release of vcpkg broke some things. I will open an issue there and create a new pull request once the issue is solved (builds times of Windows will be slower but that should not be a problem).

Sorry for all the failed workflow messages ;)

Edit: opened an [issue](https://github.com/microsoft/vcpkg/issues/12292) in vcpkg.